### PR TITLE
add basic redis tls support

### DIFF
--- a/add-expire/expire.js
+++ b/add-expire/expire.js
@@ -4,15 +4,18 @@
 
 const Redis = require('ioredis');
 const { argv } = require('yargs')
+  .boolean('t')
   .default('h', '127.0.0.1')
   .default('p', 6379)
   .default('a', '')
+  .default('t', false)
   .default('pattern', '*')
   .default('time', 60 * 60 * 24 * 30 * 3); // 60 * 60 * 24 * 30 * 3
 
 const host = argv.h;
 const port = argv.p;
 const auth = argv.a;
+const tls = argv.t;
 const { pattern } = argv;
 const { time } = argv;
 
@@ -21,11 +24,17 @@ let keysCount = 0;
 const startTime = new Date();
 const promises = [];
 
-const redis = new Redis({
+let redisConfig = {
   host: host,
   port: port,
   password: auth
-});
+}
+
+if (tls === true) (
+  redisConfig.tls = {}
+)
+
+const redis = new Redis(redisConfig);
 
 // Start scanning
 const stream = redis.scanStream({

--- a/add-expire/package.json
+++ b/add-expire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-expire",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,11 +10,11 @@
   "license": "ISC",
   "dependencies": {
     "ioredis": "^4.14.1",
-    "yargs": "^14.2.0"
+    "yargs": "^15.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.17.3"
   }
 }

--- a/add-expire/readme.md
+++ b/add-expire/readme.md
@@ -12,12 +12,13 @@ chmod +x ./expire.js
 ### Usage
 
 ```bash
-./expire.js [-h] [-p] [-a] [--pattern] [--time]
+./expire.js [-h] [-p] [-a] [-t] [--pattern] [--time]
 ```
 
 ### Options [default]
 * `-h` Redis hostname [127.0.0.1]
 * `-p` Redis port [6379]
 * `-a` Redis auth ['']
+* `-t` Redis TLS [false]
 * `--pattern` Glob pattern [\*]
 * `--time` Expiration time in seconds [7776000]

--- a/count/count.js
+++ b/count/count.js
@@ -4,25 +4,34 @@
 
 const Redis = require('ioredis');
 const { argv } = require('yargs')
+  .boolean('t')
   .default('h', '127.0.0.1')
   .default('p', 6379)
   .default('a', '')
+  .default('t', false)
   .default('pattern', '*');
 
 const host = argv.h;
 const port = argv.p;
 const auth = argv.a;
+const tls = argv.t;
 const { pattern } = argv;
 
 let roundCount = 0;
 let keysCount = 0;
 const startTime = new Date();
 
-const redis = new Redis({
+let redisConfig = {
   host: host,
   port: port,
   password: auth
-});
+}
+
+if (tls === true) (
+  redisConfig.tls = {}
+)
+
+const redis = new Redis(redisConfig);
 
 // Start scanning
 const stream = redis.scanStream({

--- a/count/package.json
+++ b/count/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-count",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,11 +10,11 @@
   "license": "ISC",
   "dependencies": {
     "ioredis": "^4.14.1",
-    "yargs": "^14.2.0"
+    "yargs": "^15.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.17.3"
   }
 }

--- a/count/readme.md
+++ b/count/readme.md
@@ -12,11 +12,12 @@ chmod +x ./count.js
 ### Usage
 
 ```bash
-./count.js [-h] [-p] [-a] [--pattern]
+./count.js [-h] [-p] [-a] [-t] [--pattern]
 ```
 
 ### Options [default]
 * `-h` Redis hostname [127.0.0.1]
 * `-p` Redis port [6379]
 * `-a` Redis auth ['']
+* `-t` Redis TLS [false]
 * `--pattern` Glob pattern [\*]

--- a/migrate/download.js
+++ b/migrate/download.js
@@ -5,15 +5,18 @@
 const Redis = require('ioredis');
 const fs = require('fs');
 const { argv } = require('yargs')
+  .boolean('t')
   .default('h', '127.0.0.1')
   .default('p', 6379)
   .default('a', '')
+  .default('t', false)
   .default('pattern', '*')
   .default('filename', 'dump.json');
 
 const host = argv.h;
 const port = argv.p;
 const auth = argv.a;
+const tls = argv.t;
 const { pattern } = argv;
 const { filename } = argv;
 
@@ -22,11 +25,17 @@ let keyCount = 0;
 let sep = '';
 const startTime = new Date();
 
-const redis = new Redis({
+let redisConfig = {
   host: host,
   port: port,
   password: auth
-});
+}
+
+if (tls === true) (
+  redisConfig.tls = {}
+)
+
+const redis = new Redis(redisConfig);
 
 // Delete previous file
 if (fs.existsSync(filename)) {

--- a/migrate/package.json
+++ b/migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-migrate",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -11,11 +11,11 @@
   "dependencies": {
     "ioredis": "^4.14.1",
     "stream-json": "^1.3.1",
-    "yargs": "^14.2.0"
+    "yargs": "^15.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.17.3"
   }
 }

--- a/migrate/readme.md
+++ b/migrate/readme.md
@@ -17,22 +17,24 @@ chmod +x ./upload.js
 ### download.js usage
 
 ```bash
-./download.js [-h] [-p] [-a] [--pattern] [--filename]
+./download.js [-h] [-p] [-a] [-t] [--pattern] [--filename]
 ```
 ### download.js options [default]
 * `-h` **origin** Redis hostname [127.0.0.1]
 * `-p` **origin** Redis port [6379]
 * `-a` **origin** Redis auth ['']
+* `-t` **origin** Redis TLS [false]
 * `--pattern` Glob pattern [\*]
 * `--filename` Filename of the json [dump.json]
 
 ### upload.js usage
 
 ```bash
-./upload.js [-h] [-p] [-a] [--filename]
+./upload.js [-h] [-p] [-a] [-t] [--filename]
 ```
 ### upload.js options [default]
 * `-h` **destination** Redis hostname [127.0.0.1]
 * `-p` **destination** Redis port [6379]
 * `-a` **destination** Redis auth ['']
+* `-t` **destination** Redis TLS [false]
 * `--filename` Filename of the json [dump.json]

--- a/migrate/upload.js
+++ b/migrate/upload.js
@@ -6,14 +6,17 @@ const Redis = require('ioredis');
 const fs = require('fs');
 const { parser } = require('stream-json/Parser');
 const { argv } = require('yargs')
+  .boolean('t')
   .default('h', '127.0.0.1')
   .default('p', 6379)
   .default('a', '')
+  .default('t', false)
   .default('filename', 'dump.json');
 
 const host = argv.h;
 const port = argv.p;
 const auth = argv.a;
+const tls = argv.t;
 const { filename } = argv;
 
 const startTime = new Date();
@@ -22,11 +25,17 @@ let value;
 let keysCount = 0;
 const promises = [];
 
-const redis = new Redis({
+let redisConfig = {
   host: host,
   port: port,
   password: auth
-});
+}
+
+if (tls === true) (
+  redisConfig.tls = {}
+)
+
+const redis = new Redis(redisConfig);
 
 const pipeline = fs.createReadStream(filename).pipe(parser());
 pipeline.on('data', (data) => {

--- a/oldest-key/oldest.js
+++ b/oldest-key/oldest.js
@@ -4,23 +4,32 @@
 
 const Redis = require('ioredis');
 const { argv } = require('yargs')
+  .boolean('t')
   .default('h', '127.0.0.1')
   .default('p', 6379)
-  .default('a', '');
+  .default('a', '')
+  .default('t', false);
 
 const host = argv.h;
 const port = argv.p;
 const auth = argv.a;
+const tls = argv.t;
 
 const startTime = new Date();
 let oldestIdle = -1;
 let pipeline;
 
-const redis = new Redis({
+let redisConfig = {
   host: host,
   port: port,
   password: auth
-});
+}
+
+if (tls === true) (
+  redisConfig.tls = {}
+)
+
+const redis = new Redis(redisConfig);
 
 // Start scanning
 const stream = redis.scanStream({

--- a/oldest-key/package.json
+++ b/oldest-key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-oldest-key",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,11 +10,11 @@
   "license": "ISC",
   "dependencies": {
     "ioredis": "^4.14.1",
-    "yargs": "^14.2.0"
+    "yargs": "^15.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.17.3"
   }
 }

--- a/oldest-key/readme.md
+++ b/oldest-key/readme.md
@@ -12,10 +12,11 @@ chmod +x ./oldest.js
 ### Usage
 
 ```bash
-./oldest.js [-h] [-p] [-a]
+./oldest.js [-h] [-p] [-a] [-t]
 ```
 
 ### Options [default]
 * `-h` Redis hostname [127.0.0.1]
 * `-p` Redis port [6379]
 * `-a` Redis auth ['']
+* `-t` Redis TLS [false]

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,14 @@ chmod +x ./count.js
 ### Usage
 
 ```bash
-./count.js [-h] [-p] [-a] [--pattern]
+./count.js [-h] [-p] [-a] [-t] [--pattern]
 ```
 
 ### Options [default]
 * `-h` Redis hostname [127.0.0.1]
 * `-p` Redis port [6379]
 * `-a` Redis auth ['']
+* `-t` Redis TLS [false]
 * `--pattern` Glob pattern [\*]
 
 ___
@@ -41,13 +42,14 @@ chmod +x ./expire.js
 ### Usage
 
 ```bash
-./expire.js [-h] [-p] [-a] [--pattern] [--time]
+./expire.js [-h] [-p] [-a] [-t] [--pattern] [--time]
 ```
 
 ### Options [default]
 * `-h` Redis hostname [127.0.0.1]
 * `-p` Redis port [6379]
 * `-a` Redis auth ['']
+* `-t` Redis TLS [false]
 * `--pattern` Glob pattern [\*]
 * `--time` Expiration time in seconds [7776000]
 
@@ -73,24 +75,26 @@ chmod +x ./upload.js
 ### download.js usage
 
 ```bash
-./download.js [-h] [-p] [-a] [--pattern] [--filename]
+./download.js [-h] [-p] [-a] [-t] [--pattern] [--filename]
 ```
 ### download.js options [default]
 * `-h` **origin** Redis hostname [127.0.0.1]
 * `-p` **origin** Redis port [6379]
 * `-a` **origin** Redis auth ['']
+* `-t` **origin** Redis TLS [false]
 * `--pattern` Glob pattern [\*]
 * `--filename` Filename of the json [dump.json]
 
 ### upload.js usage
 
 ```bash
-./upload.js [-h] [-p] [-a] [--filename]
+./upload.js [-h] [-p] [-a] [-t] [--filename]
 ```
 ### upload.js options [default]
 * `-h` **destination** Redis hostname [127.0.0.1]
 * `-p` **destination** Redis port [6379]
 * `-a` **destination** Redis auth ['']
+* `-t` **destination** Redis TLS [false]
 * `--filename` Filename of the json [dump.json]
 
 ___
@@ -110,10 +114,11 @@ chmod +x ./oldest.js
 ### Usage
 
 ```bash
-./oldest.js [-h] [-p] [-a]
+./oldest.js [-h] [-p] [-a] [-t]
 ```
 
 ### Options [default]
 * `-h` Redis hostname [127.0.0.1]
 * `-p` Redis port [6379]
 * `-a` Redis auth ['']
+* `-t` Redis TLS [false]


### PR DESCRIPTION
One more quick PR to add basic support for Redis TLS (Azure Cache & AWS ElastiCache).